### PR TITLE
feat/33 todos repo firestore

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "gatherly-67b9c"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .externalNativeBuild
 .cxx
 local.properties
+#Firebase config
+google-services.json
 
 # Keystore files
 *.jks

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ google-services.json
 # Keystore files
 *.jks
 *.keystore
+
+# Firebase emulator logs
+firestore-debug.log
+
+# Local dev/test directories
+app/src/main/java/com/android/gatherly/model/map/

--- a/app/src/androidTest/java/com/android/gatherly/model/todo/ToDosRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/gatherly/model/todo/ToDosRepositoryFirestoreTest.kt
@@ -1,0 +1,145 @@
+package com.android.gatherly.model.todo
+
+import com.android.gatherly.model.map.Location
+import com.android.gatherly.utils.FirestoreGatherlyTest
+import com.google.firebase.Timestamp
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.NoSuchElementException
+
+/**
+ * Integration tests for [ToDosRepositoryFirestore] using the Firebase Emulator Suite.
+ *
+ * These tests assume:
+ * - The Firestore and Auth emulators are running locally.
+ */
+class ToDosRepositoryFirestoreTest : FirestoreGatherlyTest() {
+
+    @Test
+    fun add_and_getAll_works() = runTest {
+        repository.addTodo(todo1)
+        repository.addTodo(todo2)
+
+        val todos = repository.getAllTodos()
+        assertEquals(2, todos.size)
+        assertTrue(todos.any { it.name == "Buy groceries" })
+        assertTrue(todos.any { it.name == "Walk the dog" })
+    }
+
+    @Test
+    fun getTodo_returns_exact_todo() = runTest {
+        repository.addTodo(todo1)
+
+        val retrieved = repository.getTodo(todo1.uid)
+        assertEquals(todo1.uid, retrieved.uid)
+        assertEquals(todo1.name, retrieved.name)
+        assertEquals(todo1.description, retrieved.description)
+        assertEquals(todo1.status, retrieved.status)
+    }
+
+    @Test
+    fun getTodo_throws_when_not_found() = runTest {
+        try {
+            repository.getTodo("non_existing_id")
+            fail("Expected NoSuchElementException to be thrown")
+        } catch (e: NoSuchElementException) {
+            // Expected
+        }
+    }
+
+    @Test
+    fun addTodo_with_location_and_dueTime_stores_correctly() = runTest {
+        val todoWithExtras = todo1.copy(
+            uid = "x1",
+            location = Location(46.52, 6.57, "EPFL"),
+            dueTime = Timestamp.now()
+        )
+
+        repository.addTodo(todoWithExtras)
+        val fetched = repository.getTodo("x1")
+
+        assertEquals("EPFL", fetched.location?.name)
+        assertNotNull(fetched.dueTime)
+        assertEquals(46.52, fetched.location?.latitude ?: 0.0, 0.0001)
+
+    }
+
+    @Test
+    fun editTodo_updates_existing_todo() = runTest {
+        repository.addTodo(todo1)
+
+        val updated = todo1.copy(
+            name = "Buy groceries (updated)",
+            description = "Add coffee",
+            status = ToDoStatus.ENDED
+        )
+        repository.editTodo(todo1.uid, updated)
+
+        val fetched = repository.getTodo(todo1.uid)
+        assertEquals("Buy groceries (updated)", fetched.name)
+        assertEquals("Add coffee", fetched.description)
+        assertEquals(ToDoStatus.ENDED, fetched.status)
+    }
+
+    @Test
+    fun deleteTodo_removes_it() = runTest {
+        repository.addTodo(todo1)
+        repository.addTodo(todo2)
+        assertEquals(2, getTodosCount())
+
+        repository.deleteTodo(todo1.uid)
+        val todos = repository.getAllTodos()
+        assertEquals(1, todos.size)
+        assertEquals(todo2.uid, todos.first().uid)
+    }
+
+    @Test
+    fun deleteTodo_throws_if_not_found() = runTest {
+        try {
+            repository.deleteTodo("invalid_id")
+            fail("Expected NoSuchElementException to be thrown")
+        } catch (e: NoSuchElementException) {
+            // Expected
+        }
+    }
+
+
+    @Test
+    fun toggleStatus_flips_status_correctly() = runTest {
+        repository.addTodo(todo1)
+        val original = repository.getTodo(todo1.uid)
+        assertEquals(ToDoStatus.ONGOING, original.status)
+
+        repository.toggleStatus(todo1.uid)
+        val toggled = repository.getTodo(todo1.uid)
+        assertEquals(ToDoStatus.ENDED, toggled.status)
+
+        repository.toggleStatus(todo1.uid)
+        val backToOngoing = repository.getTodo(todo1.uid)
+        assertEquals(ToDoStatus.ONGOING, backToOngoing.status)
+    }
+
+    @Test
+    fun getAllEndedTodos_returns_only_completed() = runTest {
+        val ended = todo1.copy(uid = "a", status = ToDoStatus.ENDED)
+        val ongoing = todo2.copy(uid = "b", status = ToDoStatus.ONGOING)
+        val ended2 = todo3.copy(uid = "c", status = ToDoStatus.ENDED)
+
+        repository.addTodo(ended)
+        repository.addTodo(ongoing)
+        repository.addTodo(ended2)
+
+        val endedTodos = repository.getAllEndedTodos()
+        assertEquals(2, endedTodos.size)
+        assertTrue(endedTodos.all { it.status == ToDoStatus.ENDED })
+    }
+
+    @Test
+    fun getNewUid_returns_unique_values() {
+        val id1 = repository.getNewUid()
+        val id2 = repository.getNewUid()
+        assertNotEquals(id1, id2)
+        assertTrue(id1.isNotEmpty())
+    }
+}

--- a/app/src/androidTest/java/com/android/gatherly/utils/FakeHttpClient.kt
+++ b/app/src/androidTest/java/com/android/gatherly/utils/FakeHttpClient.kt
@@ -1,0 +1,123 @@
+package com.android.gatherly.utils
+
+import android.util.Log
+import com.android.gatherly.model.map.Location
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+
+/**
+ * A fake HTTP client that intercepts requests and provides predefined responses for testing
+ * location search functionality.
+ */
+object FakeHttpClient {
+    enum class FakeLocation(val queryName: String) {
+        EPFL("EPFL"),
+        LAUSANNE("Lausanne"),
+        NOWHERE("Nowhere"),
+        EVERYWHERE("Everywhere"),
+        TOO_LONG("Too long"),
+    }
+
+    private const val NOMINATIM_HOST = "nominatim.openstreetmap.org"
+    private const val SEARCH_PATH = "search"
+    private val QUERY_PARAMETERS =
+        mapOf("q" to FakeLocation.entries.map { it.queryName }.toSet(), "format" to setOf("json"))
+
+    val FakeLocation.locationSuggestions: List<Location>
+        get() =
+            when (this) {
+                FakeLocation.EPFL -> listOf(Location(46.5221982, 6.5661540, "Fake EPFL"))
+                FakeLocation.LAUSANNE ->
+                    listOf(
+                        Location(46.5196535, 6.6322734, "Fake Lausanne"),
+                    )
+                FakeLocation.NOWHERE -> emptyList()
+                FakeLocation.EVERYWHERE ->
+                    (0..50).toList<Int>().map { Location(0.0 + it, 0.0 + it, "Somewhere $it") }
+                FakeLocation.TOO_LONG ->
+                    listOf(
+                        Location(
+                            0.0,
+                            0.0,
+                            "This is a very long location name designed to test how the application handles location names that exceed typical lengths, ensuring that text wrapping, truncation, or overflow behaviors are correctly implemented in the UI components that display location information."))
+            }
+
+    val FakeLocation.getRequestURL: String
+        get() = "https://nominatim.openstreetmap.org/search?q=${queryName}&format=json"
+
+    val FakeLocation.locationSuggestionsAsJson: String
+        get() =
+            "[" +
+                    locationSuggestions.joinToString(",") {
+                        """{
+        "place_id": 0,
+        "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright",
+        "osm_type": "node",
+        "osm_id": 0,
+        "lat": "${it.latitude}",
+        "lon": "${it.longitude}",
+        "class": "railway",
+        "type": "station",
+        "place_rank": 0,
+        "importance": 0.5,
+        "addresstype": "railway",
+        "name": "${it.name}",
+        "display_name": "${it.name}",
+        "boundingbox": [
+        "${it.latitude - 0.1}",
+        "${it.latitude + 0.1}",
+        "${it.longitude - 0.1}",
+        "${it.longitude + 0.1}"
+        ]
+    }"""
+                    } +
+                    "]"
+
+    private class NominatimAPIInterceptor(val checkUrl: Boolean) : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val request = chain.request()
+            val url = request.url.toString()
+
+            Log.d("MockInterceptor", "Intercepted URL: $url")
+            if (checkUrl) {
+                assertTrue("Request must use HTTPS", request.url.isHttps)
+                assertTrue("Invalid host in $url", request.url.host.contains("nominatim.openstreetmap.org"))
+                assertNotNull(request.url.queryParameter("q"))
+                assertEquals("json", request.url.queryParameter("format"))
+            }
+            if (request.url.host == NOMINATIM_HOST &&
+                request.url.pathSegments.contains(SEARCH_PATH) &&
+                QUERY_PARAMETERS.all { (k, v) -> v.contains(request.url.queryParameter(k)) }) {
+                val location =
+                    FakeLocation.entries.find { request.url.queryParameter("q") == it.queryName }!!
+                Log.d("MockInterceptor", "Matched FakeLocation: ${location.queryName}")
+                return Response.Builder()
+                    .code(200)
+                    .message("OK")
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .body(
+                        location.locationSuggestionsAsJson.toResponseBody("application/json".toMediaType()))
+                    .build()
+            }
+            Log.d("MockInterceptor", "No match found for URL: $url")
+            return Response.Builder()
+                .code(404)
+                .message("Not Found")
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .body("{\"error\":\"Not Found\"}".toResponseBody("application/json".toMediaType()))
+                .build()
+        }
+    }
+
+    fun getClient(checkUrl: Boolean = false): OkHttpClient =
+        OkHttpClient.Builder().addInterceptor(NominatimAPIInterceptor(checkUrl)).build()
+}

--- a/app/src/androidTest/java/com/android/gatherly/utils/FirebaseEmulator.kt
+++ b/app/src/androidTest/java/com/android/gatherly/utils/FirebaseEmulator.kt
@@ -1,0 +1,151 @@
+package com.android.gatherly.utils
+
+import android.util.Log
+import com.google.firebase.Firebase
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.auth
+import com.google.firebase.firestore.firestore
+import io.mockk.InternalPlatformDsl.toArray
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+/**
+ * An object to manage the connection to Firebase Emulators for Android tests.
+ *
+ * This object will automatically use the emulators if they are running when the tests start.
+ */
+object FirebaseEmulator {
+    val auth
+        get() = Firebase.auth
+
+    val firestore
+        get() = Firebase.firestore
+
+    const val HOST = "10.0.2.2"
+    const val EMULATORS_PORT = 4400
+    const val FIRESTORE_PORT = 8080
+    const val AUTH_PORT = 9099
+
+    val projectID by lazy { FirebaseApp.getInstance().options.projectId }
+
+    private val httpClient = OkHttpClient()
+    private val firestoreEndpoint by lazy {
+        "http://${HOST}:$FIRESTORE_PORT/emulator/v1/projects/$projectID/databases/(default)/documents"
+    }
+
+    private val authEndpoint by lazy {
+        "http://${HOST}:$AUTH_PORT/emulator/v1/projects/$projectID/accounts"
+    }
+
+    private val emulatorsEndpoint = "http://$HOST:$EMULATORS_PORT/emulators"
+
+    private fun areEmulatorsRunning(): Boolean =
+        runCatching {
+            val client = httpClient
+            val request = Request.Builder().url(emulatorsEndpoint).build()
+            client.newCall(request).execute().isSuccessful
+        }
+            .getOrNull() == true
+
+    val isRunning = areEmulatorsRunning()
+
+    init {
+        if (isRunning) {
+            auth.useEmulator(HOST, AUTH_PORT)
+            firestore.useEmulator(HOST, FIRESTORE_PORT)
+            assert(Firebase.firestore.firestoreSettings.host.contains(HOST)) {
+                "Failed to connect to Firebase Firestore Emulator."
+            }
+        }
+    }
+
+    private fun clearEmulator(endpoint: String) {
+        val client = httpClient
+        val request = Request.Builder().url(endpoint).delete().build()
+        val response = client.newCall(request).execute()
+
+        assert(response.isSuccessful) { "Failed to clear emulator at $endpoint" }
+    }
+
+    fun clearAuthEmulator() {
+        clearEmulator(authEndpoint)
+    }
+
+    fun clearFirestoreEmulator() {
+        clearEmulator(firestoreEndpoint)
+    }
+
+    /**
+     * Seeds a Google user in the Firebase Auth Emulator using a fake JWT id_token.
+     *
+     * @param fakeIdToken A JWT-shaped string, must contain at least "sub".
+     * @param email The email address to associate with the account.
+     */
+    fun createGoogleUser(fakeIdToken: String) {
+        val url =
+            "http://$HOST:$AUTH_PORT/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake-api-key"
+
+        // postBody must be x-www-form-urlencoded style string, wrapped in JSON
+        val postBody = "id_token=$fakeIdToken&providerId=google.com"
+
+        val requestJson =
+            JSONObject().apply {
+                put("postBody", postBody)
+                put("requestUri", "http://localhost")
+                put("returnIdpCredential", true)
+                put("returnSecureToken", true)
+            }
+
+        val mediaType = "application/json; charset=utf-8".toMediaType()
+        val body = requestJson.toString().toRequestBody(mediaType)
+
+        val request =
+            Request.Builder().url(url).post(body).addHeader("Content-Type", "application/json").build()
+
+        val response = httpClient.newCall(request).execute()
+        assert(response.isSuccessful) {
+            "Failed to create user in Auth Emulator: ${response.code} ${response.message}"
+        }
+    }
+
+    fun changeEmail(fakeIdToken: String, newEmail: String) {
+        val response =
+            httpClient
+                .newCall(
+                    Request.Builder()
+                        .url(
+                            "http://$HOST:$AUTH_PORT/identitytoolkit.googleapis.com/v1/accounts:update?key=fake-api-key")
+                        .post(
+                            """
+            {
+                "idToken": "$fakeIdToken",
+                "email": "$newEmail",
+                "returnSecureToken": true
+            }
+        """
+                                .trimIndent()
+                                .toRequestBody())
+                        .build())
+                .execute()
+        assert(response.isSuccessful) {
+            "Failed to change email in Auth Emulator: ${response.code} ${response.message}"
+        }
+    }
+
+    val users: String
+        get() {
+            val request =
+                Request.Builder()
+                    .url(
+                        "http://$HOST:$AUTH_PORT/identitytoolkit.googleapis.com/v1/accounts:query?key=fake-api-key")
+                    .build()
+
+            Log.d("FirebaseEmulator", "Fetching users with request: ${request.url.toString()}")
+            val response = httpClient.newCall(request).execute()
+            Log.d("FirebaseEmulator", "Response received: ${response.toArray()}")
+            return response.body.toString()
+        }
+}

--- a/app/src/androidTest/java/com/android/gatherly/utils/FirestoreGatherlyTest.kt
+++ b/app/src/androidTest/java/com/android/gatherly/utils/FirestoreGatherlyTest.kt
@@ -1,0 +1,84 @@
+package com.android.gatherly.utils
+
+import android.util.Log
+import com.android.gatherly.model.todo.ToDo
+import com.android.gatherly.model.todo.ToDoStatus
+import com.android.gatherly.model.todo.ToDosRepository
+import com.android.gatherly.model.todo.ToDosRepositoryFirestore
+import com.google.firebase.Timestamp
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+
+/**
+ * Base class for Firestore-based Android tests using the Firebase Emulator Suite.
+ *
+ * Before running, start the emulators:
+ *   firebase emulators:start
+ */
+open class FirestoreGatherlyTest {
+
+    protected lateinit var repository: ToDosRepository
+
+    // Example todos used in tests
+    protected val todo1 = ToDo(
+        uid = "1",
+        name = "Buy groceries",
+        description = "Milk, eggs, bread",
+        assigneeName = "Alice",
+        dueDate = Timestamp.now(),
+        dueTime = null,
+        location = null,
+        status = ToDoStatus.ONGOING,
+        ownerId = "test-user"
+    )
+
+    protected val todo2 = todo1.copy(uid = "2", name = "Walk the dog")
+    protected val todo3 = todo1.copy(uid = "3", name = "Read a book")
+
+    @Before
+    open fun setUp() {
+        if (!FirebaseEmulator.isRunning) {
+            error("Firebase emulator must be running! Use: firebase emulators:start")
+        }
+        FirebaseEmulator.auth.signInAnonymously()
+        repository = ToDosRepositoryFirestore(FirebaseEmulator.firestore)
+        runTest { clearUserTodos() }
+    }
+
+    @After
+    open fun tearDown() {
+        runTest { clearUserTodos() }
+        FirebaseEmulator.clearFirestoreEmulator()
+    }
+
+    /** Deletes all todos for the current test user in the emulator Firestore */
+    protected suspend fun clearUserTodos() {
+        val user = FirebaseEmulator.auth.currentUser ?: return
+        val todos = FirebaseEmulator.firestore
+            .collection("users")
+            .document(user.uid)
+            .collection("todos")
+            .get()
+            .await()
+
+        val batch = FirebaseEmulator.firestore.batch()
+        todos.documents.forEach { batch.delete(it.reference) }
+        batch.commit().await()
+
+        Log.d("FirestoreGatherlyTest", "Cleared ${todos.size()} todos for user ${user.uid}")
+    }
+
+    /** Returns the current count of todos for this user. */
+    protected suspend fun getTodosCount(): Int {
+        val user = FirebaseEmulator.auth.currentUser ?: return 0
+        val snap = FirebaseEmulator.firestore
+            .collection("users")
+            .document(user.uid)
+            .collection("todos")
+            .get()
+            .await()
+        return snap.size()
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SampleApp"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".SecondActivity"

--- a/app/src/main/java/com/android/gatherly/FirebaseInit.kt
+++ b/app/src/main/java/com/android/gatherly/FirebaseInit.kt
@@ -1,0 +1,27 @@
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreSettings
+import com.google.firebase.firestore.PersistentCacheSettings
+
+object FirebaseInit {
+
+    /**
+     * Enables offline persistence for Firestore.
+     *
+     * This sets up Firestore with a local cache that persists data across
+     * app restarts and synchronizes with the cloud once connectivity is restored.
+     *
+     * Must be called before any Firestore operations (e.g., repository usage)
+     * to ensure persistence is active for all instances.
+     *
+     * This should be called once in app startup (MainActivity onCreate).
+     */
+    fun enableOfflinePersistence() { //to be called in MainActivity in onCreate
+        val firestore = FirebaseFirestore.getInstance()
+
+        val settings = FirebaseFirestoreSettings.Builder()
+            .setLocalCacheSettings(PersistentCacheSettings.newBuilder().build())
+            .build()
+
+        firestore.firestoreSettings = settings
+    }
+}

--- a/app/src/main/java/com/android/gatherly/model/todo/ToDo.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/ToDo.kt
@@ -1,0 +1,31 @@
+package com.android.gatherly.model.todo
+
+import com.google.firebase.Timestamp
+import java.util.Locale
+
+data class ToDo(
+    val uid: String,
+    val name: String,
+    val description: String,
+    val assigneeName: String,
+    val dueDate: Timestamp,
+    val status: ToDoStatus,
+    val ownerId: String
+)
+
+enum class ToDoStatus {
+    CREATED,
+    STARTED,
+    ENDED,
+    ARCHIVED
+}
+
+/**
+ * Converts the ToDoStatus enum to a more readable display string (camel case).
+ *
+ * @return A string representation of the ToDoStatus, formatted for display.
+ */
+fun ToDoStatus.displayString(): String =
+    name.replace("_", " ").lowercase(Locale.ROOT).replaceFirstChar {
+        if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+    }

--- a/app/src/main/java/com/android/gatherly/model/todo/ToDo.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/ToDo.kt
@@ -3,6 +3,9 @@ package com.android.gatherly.model.todo
 import com.google.firebase.Timestamp
 import java.util.Locale
 
+/**
+ * Represents a single [ToDo] item within the app.
+ */
 data class ToDo(
     val uid: String,
     val name: String,
@@ -13,11 +16,12 @@ data class ToDo(
     val ownerId: String
 )
 
+/**
+ * Represents the state of a [ToDo] item.
+ */
 enum class ToDoStatus {
-    CREATED,
-    STARTED,
-    ENDED,
-    ARCHIVED
+  ONGOING,
+  ENDED
 }
 
 /**
@@ -27,5 +31,5 @@ enum class ToDoStatus {
  */
 fun ToDoStatus.displayString(): String =
     name.replace("_", " ").lowercase(Locale.ROOT).replaceFirstChar {
-        if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+      if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
     }

--- a/app/src/main/java/com/android/gatherly/model/todo/ToDo.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/ToDo.kt
@@ -1,5 +1,6 @@
 package com.android.gatherly.model.todo
 
+import com.android.gatherly.model.map.Location
 import com.google.firebase.Timestamp
 import java.util.Locale
 
@@ -13,6 +14,7 @@ data class ToDo(
     val assigneeName: String,
     val dueDate: Timestamp,
     val dueTime: Timestamp?,
+    val location: Location?,
     val status: ToDoStatus,
     val ownerId: String
 )

--- a/app/src/main/java/com/android/gatherly/model/todo/ToDo.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/ToDo.kt
@@ -12,6 +12,7 @@ data class ToDo(
     val description: String,
     val assigneeName: String,
     val dueDate: Timestamp,
+    val dueTime: Timestamp?,
     val status: ToDoStatus,
     val ownerId: String
 )

--- a/app/src/main/java/com/android/gatherly/model/todo/ToDosRepository.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/ToDosRepository.kt
@@ -1,0 +1,48 @@
+package com.android.gatherly.model.todo
+
+/** Represents a repository that manages ToDo items. */
+interface ToDosRepository {
+
+    /** Generates and returns a new unique identifier for a ToDo item. */
+    fun getNewUid(): String
+
+    /**
+     * Retrieves all ToDo items from the repository.
+     *
+     * @return A list of all ToDo items.
+     */
+    suspend fun getAllTodos(): List<ToDo>
+
+    /**
+     * Retrieves a specific ToDo item by its unique identifier.
+     *
+     * @param todoID The unique identifier of the ToDo item to retrieve.
+     * @return The ToDo item with the specified identifier.
+     * @throws Exception if the ToDo item is not found.
+     */
+    suspend fun getTodo(todoID: String): ToDo
+
+    /**
+     * Adds a new ToDo item to the repository.
+     *
+     * @param toDo The ToDo item to add.
+     */
+    suspend fun addTodo(toDo: ToDo)
+
+    /**
+     * Edits an existing ToDo item in the repository.
+     *
+     * @param todoID The unique identifier of the ToDo item to edit.
+     * @param newValue The new value for the ToDo item.
+     * @throws Exception if the ToDo item is not found.
+     */
+    suspend fun editTodo(todoID: String, newValue: ToDo)
+
+    /**
+     * Deletes a ToDo item from the repository.
+     *
+     * @param todoID The unique identifier of the ToDo item to delete.
+     * @throws Exception if the ToDo item is not found.
+     */
+    suspend fun deleteTodo(todoID: String)
+}

--- a/app/src/main/java/com/android/gatherly/model/todo/ToDosRepository.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/ToDosRepository.kt
@@ -1,48 +1,63 @@
 package com.android.gatherly.model.todo
 
-/** Represents a repository that manages ToDo items. */
+/**
+ * Repository interface that defines all operations for managing [ToDo] items.
+ *
+ * This abstraction allows different data sources (e.g., Firestore, local DB, or fake data)
+ */
 interface ToDosRepository {
 
-    /** Generates and returns a new unique identifier for a ToDo item. */
-    fun getNewUid(): String
+  /** Generates and returns a new unique identifier for a [ToDo] item. */
+  fun getNewUid(): String
 
-    /**
-     * Retrieves all ToDo items from the repository.
-     *
-     * @return A list of all ToDo items.
-     */
-    suspend fun getAllTodos(): List<ToDo>
+  /**
+   * Retrieves all [ToDo] items from the repository.
+   *
+   * @return A list of all [ToDo] items.
+   */
+  suspend fun getAllTodos(): List<ToDo>
 
-    /**
-     * Retrieves a specific ToDo item by its unique identifier.
-     *
-     * @param todoID The unique identifier of the ToDo item to retrieve.
-     * @return The ToDo item with the specified identifier.
-     * @throws Exception if the ToDo item is not found.
-     */
-    suspend fun getTodo(todoID: String): ToDo
+  /**
+   * Retrieves a specific [ToDo] item by its unique identifier.
+   *
+   * @param todoID The unique identifier of the [ToDo] item to retrieve.
+   * @return The [ToDo] item with the specified identifier.
+   */
+  suspend fun getTodo(todoID: String): ToDo
 
-    /**
-     * Adds a new ToDo item to the repository.
-     *
-     * @param toDo The ToDo item to add.
-     */
-    suspend fun addTodo(toDo: ToDo)
+  /**
+   * Adds a new [ToDo] item to the repository.
+   *
+   * @param toDo The [ToDo] item to add.
+   */
+  suspend fun addTodo(toDo: ToDo)
 
-    /**
-     * Edits an existing ToDo item in the repository.
-     *
-     * @param todoID The unique identifier of the ToDo item to edit.
-     * @param newValue The new value for the ToDo item.
-     * @throws Exception if the ToDo item is not found.
-     */
-    suspend fun editTodo(todoID: String, newValue: ToDo)
+  /**
+   * Edits an existing [ToDo] item in the repository.
+   *
+   * @param todoID The unique identifier of the [ToDo] item to edit.
+   * @param newValue The new value for the [ToDo] item.
+   */
+  suspend fun editTodo(todoID: String, newValue: ToDo)
 
-    /**
-     * Deletes a ToDo item from the repository.
-     *
-     * @param todoID The unique identifier of the ToDo item to delete.
-     * @throws Exception if the ToDo item is not found.
-     */
-    suspend fun deleteTodo(todoID: String)
+  /**
+   * Deletes a [ToDo] item from the repository.
+   *
+   * @param todoID The unique identifier of the [ToDo] item to delete.
+   */
+  suspend fun deleteTodo(todoID: String)
+
+  /**
+   * Toggles the status of a [ToDo] (e.g., between ongoing and ended).
+   *
+   * @param todoID The identifier of the [ToDo] to toggle.
+   */
+  suspend fun toggleStatus(todoID: String)
+
+  /**
+   * Retrieves all [ToDo] items marked as ended from the repository.
+   *
+   * @return A list of all [ToDo] items marked as ended.
+   */
+  suspend fun getAllEndedTodos(): List<ToDo>
 }

--- a/app/src/main/java/com/android/gatherly/model/todo/TodosRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/TodosRepositoryFirestore.kt
@@ -1,0 +1,95 @@
+package com.android.gatherly.model.todo
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import java.util.NoSuchElementException
+import kotlinx.coroutines.tasks.await
+
+
+class ToDosRepositoryFirestore(private val db: FirebaseFirestore) : ToDosRepository {
+
+    private val collection = db.collection("todos")
+
+    private fun currentUserId(): String {
+        return FirebaseAuth.getInstance().currentUser?.uid
+            ?: throw IllegalStateException("No signed in user")
+    }
+
+    override fun getNewUid(): String {
+        // Important: document() doesn’t contact Firestore yet. It just creates a reference.
+        return collection.document().id
+    }
+
+    override suspend fun getAllTodos(): List<ToDo> {
+        val snap =
+            collection
+                .whereEqualTo("ownerId", currentUserId())
+                .get()
+                .await() // QuerySnapShot in this case pretty much list of docs.
+        return snap.documents.mapNotNull { doc -> snapshotToToDo(doc) }
+    }
+
+    override suspend fun getTodo(todoID: String): ToDo {
+        val doc = collection.document(todoID).get().await()
+        val todo = snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
+        if (todo.ownerId != currentUserId()) {
+            throw SecurityException("Todo doesn't belong to signed in user.")
+        }
+        return todo
+    }
+
+    override suspend fun addTodo(toDo: ToDo) {
+        val ownedToDo = toDo.copy(ownerId = currentUserId())
+        collection.document(ownedToDo.uid).set(todoToMap(ownedToDo)).await() // set takes a Map
+    }
+
+    override suspend fun editTodo(todoID: String, newValue: ToDo) {
+        val doc = collection.document(todoID).get().await()
+        val existing =
+            snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
+
+        if (existing.ownerId != currentUserId()) {
+            throw SecurityException("Todo does not belong to signed in user")
+        }
+
+        val newValue = newValue.copy(ownerId = currentUserId())
+        collection.document(todoID).set(todoToMap(newValue)).await()
+    }
+
+    override suspend fun deleteTodo(todoID: String) {
+        val doc = collection.document(todoID).get().await()
+        val existing =
+            snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
+
+        if (existing.ownerId != currentUserId()) {
+            throw SecurityException("Todo does not belong to signed in user")
+        }
+
+        collection.document(todoID).delete().await()
+    }
+
+    private fun snapshotToToDo(doc: DocumentSnapshot): ToDo? {
+        val uid = doc.getString("uid") ?: return null
+        val name = doc.getString("name") ?: return null
+        val description = doc.getString("description") ?: return null
+        val assigneeName = doc.getString("assigneeName") ?: return null
+        val dueDate = doc.getTimestamp("dueDate") ?: return null
+        val ownerId = doc.getString("ownerId") ?: return null
+        val statusStr = doc.getString("status") ?: ToDoStatus.CREATED.name
+        val status = ToDoStatus.valueOf(statusStr)
+
+        return ToDo(uid, name, description, assigneeName, dueDate, status, ownerId)
+    }
+
+    private fun todoToMap(todo: ToDo): Map<String, Any?> {
+        return mapOf(
+            "uid" to todo.uid,
+            "name" to todo.name,
+            "description" to todo.description,
+            "assigneeName" to todo.assigneeName,
+            "dueDate" to todo.dueDate,
+            "status" to todo.status.name,
+            "ownerId" to todo.ownerId)
+    }
+}

--- a/app/src/main/java/com/android/gatherly/model/todo/TodosRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/TodosRepositoryFirestore.kt
@@ -1,5 +1,6 @@
 package com.android.gatherly.model.todo
 
+import com.android.gatherly.model.map.Location
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
@@ -170,11 +171,26 @@ class ToDosRepositoryFirestore(private val db: FirebaseFirestore) : ToDosReposit
     val assigneeName = doc.getString("assigneeName") ?: return null
     val dueDate = doc.getTimestamp("dueDate") ?: return null
         val dueTime = doc.getTimestamp("dueTime")
+        val locationMap =
+            doc.get("location")
+                    as?
+                    Map<*, *>
+        val location =
+            locationMap?.let { locMap ->
+                val lat = locMap["latitude"] as? Double
+                val lng = locMap["longitude"] as? Double
+                val locName = locMap["name"] as? String
+                if (lat != null && lng != null && locName != null) {
+                    Location(lat, lng, locName)
+                } else {
+                    null
+                }
+            }
     val ownerId = doc.getString("ownerId") ?: return null
     val statusStr = doc.getString("status") ?: ToDoStatus.ONGOING.name
     val status = ToDoStatus.valueOf(statusStr)
 
-    return ToDo(uid, name, description, assigneeName, dueDate, dueTime, status, ownerId)
+    return ToDo(uid, name, description, assigneeName, dueDate, dueTime, location, status, ownerId)
   }
 
     /**
@@ -193,6 +209,10 @@ class ToDosRepositoryFirestore(private val db: FirebaseFirestore) : ToDosReposit
         "assigneeName" to todo.assigneeName,
         "dueDate" to todo.dueDate,
         "dueTime" to todo.dueTime,
+        "location" to
+                todo.location?.let { loc ->
+                    mapOf("latitude" to loc.latitude, "longitude" to loc.longitude, "name" to loc.name)
+                },
         "status" to todo.status.name,
         "ownerId" to todo.ownerId)
   }

--- a/app/src/main/java/com/android/gatherly/model/todo/TodosRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/TodosRepositoryFirestore.kt
@@ -169,11 +169,12 @@ class ToDosRepositoryFirestore(private val db: FirebaseFirestore) : ToDosReposit
     val description = doc.getString("description") ?: return null
     val assigneeName = doc.getString("assigneeName") ?: return null
     val dueDate = doc.getTimestamp("dueDate") ?: return null
+        val dueTime = doc.getTimestamp("dueTime")
     val ownerId = doc.getString("ownerId") ?: return null
     val statusStr = doc.getString("status") ?: ToDoStatus.ONGOING.name
     val status = ToDoStatus.valueOf(statusStr)
 
-    return ToDo(uid, name, description, assigneeName, dueDate, status, ownerId)
+    return ToDo(uid, name, description, assigneeName, dueDate, dueTime, status, ownerId)
   }
 
     /**
@@ -191,6 +192,7 @@ class ToDosRepositoryFirestore(private val db: FirebaseFirestore) : ToDosReposit
         "description" to todo.description,
         "assigneeName" to todo.assigneeName,
         "dueDate" to todo.dueDate,
+        "dueTime" to todo.dueTime,
         "status" to todo.status.name,
         "ownerId" to todo.ownerId)
   }

--- a/app/src/main/java/com/android/gatherly/model/todo/TodosRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/gatherly/model/todo/TodosRepositoryFirestore.kt
@@ -5,91 +5,193 @@ import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import java.util.NoSuchElementException
 import kotlinx.coroutines.tasks.await
-
-
+/**
+ * Firestore-based implementation of [ToDosRepository].
+ *
+ * This repository stores each user's ToDo items under: /users/{userId}/todos/{todoId}
+ *
+ * All methods are asynchronous and must be called from a coroutine scope.
+ *
+ * @param db A [FirebaseFirestore] instance used for database operations.
+ */
 class ToDosRepositoryFirestore(private val db: FirebaseFirestore) : ToDosRepository {
 
-    private val collection = db.collection("todos")
+    /**
+     * Reference to the "todos" collection of the currently signed-in user.
+     */
+    private val collection get() = db.collection("users")
+        .document(currentUserId())
+        .collection("todos")
 
-    private fun currentUserId(): String {
-        return FirebaseAuth.getInstance().currentUser?.uid
-            ?: throw IllegalStateException("No signed in user")
+    /**
+     * Returns the UID of the currently authenticated Firebase user.
+     *
+     * @throws IllegalStateException if no user is signed in.
+     */
+  private fun currentUserId(): String {
+    return FirebaseAuth.getInstance().currentUser?.uid
+        ?: throw IllegalStateException("No signed in user")
+  }
+
+    /**
+     * Creates and returns a new Firestore document ID.
+     *
+     * This method does **not** contact Firestore; it only generates
+     * a client-side identifier that will later be used for a new document.
+     */
+  override fun getNewUid(): String {
+    return collection.document().id
+  }
+
+    /**
+     * Fetches all todos belonging to the current user.
+     *
+     * @return A list of todos owned by the user.
+     * @throws IllegalStateException if no user is signed in.
+     */
+  override suspend fun getAllTodos(): List<ToDo> {
+    val snap =
+        collection
+            .whereEqualTo("ownerId", currentUserId())
+            .get()
+            .await() // QuerySnapShot in this case pretty much list of docs.
+    return snap.documents.mapNotNull { doc -> snapshotToToDo(doc) }
+  }
+
+    /**
+     * Retrieves a single todo by ID.
+     *
+     * @param todoID The unique ID matching the wanted [ToDo].
+     * @return The matching [ToDo].
+     * @throws NoSuchElementException if the [ToDo] is missing.
+     * @throws SecurityException if the document's ownerId differs from the current user.
+     */
+  override suspend fun getTodo(todoID: String): ToDo {
+    val doc = collection.document(todoID).get().await()
+    val todo = snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
+    if (todo.ownerId != currentUserId()) {
+      throw SecurityException("Todo doesn't belong to signed in user.")
+    }
+    return todo
+  }
+
+    /**
+     * Adds a new [ToDo] for the signed-in user.
+     *
+     * Overwrites the `ownerId` field of the new [ToDo] with the current user's UID.
+     *
+     * @param toDo The [ToDo] item to create.
+     * @throws IllegalStateException if no user is signed in.
+     */
+  override suspend fun addTodo(toDo: ToDo) {
+    val ownedToDo = toDo.copy(ownerId = currentUserId())
+    collection.document(ownedToDo.uid).set(todoToMap(ownedToDo)).await()
+  }
+
+    /**
+     * Updates an existing [ToDo] with new data.
+     *
+     * @param todoID The unique ID matching the [ToDo] to update.
+     * @param newValue The new [ToDo] content to store.
+     * @throws NoSuchElementException if no document matches the given ID.
+     * @throws SecurityException if the [ToDo] is not owned by the signed-in user.
+     */
+  override suspend fun editTodo(todoID: String, newValue: ToDo) {
+    val doc = collection.document(todoID).get().await()
+    val existing =
+        snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
+
+    if (existing.ownerId != currentUserId()) {
+      throw SecurityException("Todo does not belong to signed in user")
     }
 
-    override fun getNewUid(): String {
-        // Important: document() doesn’t contact Firestore yet. It just creates a reference.
-        return collection.document().id
+    val newValue = newValue.copy(ownerId = currentUserId())
+    collection.document(todoID).set(todoToMap(newValue)).await()
+  }
+
+    /**
+     * Deletes a [ToDo] by ID.
+     *
+     * @param todoID The unique ID matching the [ToDo] to delete.
+     * @throws NoSuchElementException if the [ToDo] does not exist.
+     * @throws SecurityException if the [ToDo] is not owned by the signed-in user.
+     */
+  override suspend fun deleteTodo(todoID: String) {
+    val doc = collection.document(todoID).get().await()
+    val existing =
+        snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
+
+    if (existing.ownerId != currentUserId()) {
+      throw SecurityException("Todo does not belong to signed in user")
     }
 
-    override suspend fun getAllTodos(): List<ToDo> {
+    collection.document(todoID).delete().await()
+  }
+
+    /**
+     * Toggles a [ToDo]'s completion status between [ToDoStatus.ONGOING] and [ToDoStatus.ENDED].
+     *
+     * @param todoID The unique ID matching the [ToDo] to toggle.
+     * @throws NoSuchElementException if the [ToDo] does not exist.
+     * @throws SecurityException if the [ToDo] is not owned by the signed-in user.
+     */
+    override suspend fun toggleStatus(todoID: String) {
+        val todo = getTodo(todoID)
+        val newStatus = if (todo.status == ToDoStatus.ENDED) ToDoStatus.ONGOING else ToDoStatus.ENDED
+        editTodo(todoID, todo.copy(status = newStatus))
+    }
+
+    /**
+     * Fetches all [ToDo]s marked as [ToDoStatus.ENDED].
+     *
+     * @return A list of completed [ToDo]s of the current user.
+     * @throws IllegalStateException if no user is signed in.
+     */
+    override suspend fun getAllEndedTodos(): List<ToDo> {
         val snap =
             collection
                 .whereEqualTo("ownerId", currentUserId())
+                .whereEqualTo("status", ToDoStatus.ENDED.name)
                 .get()
                 .await() // QuerySnapShot in this case pretty much list of docs.
         return snap.documents.mapNotNull { doc -> snapshotToToDo(doc) }
     }
 
-    override suspend fun getTodo(todoID: String): ToDo {
-        val doc = collection.document(todoID).get().await()
-        val todo = snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
-        if (todo.ownerId != currentUserId()) {
-            throw SecurityException("Todo doesn't belong to signed in user.")
-        }
-        return todo
-    }
-
-    override suspend fun addTodo(toDo: ToDo) {
-        val ownedToDo = toDo.copy(ownerId = currentUserId())
-        collection.document(ownedToDo.uid).set(todoToMap(ownedToDo)).await() // set takes a Map
-    }
-
-    override suspend fun editTodo(todoID: String, newValue: ToDo) {
-        val doc = collection.document(todoID).get().await()
-        val existing =
-            snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
-
-        if (existing.ownerId != currentUserId()) {
-            throw SecurityException("Todo does not belong to signed in user")
-        }
-
-        val newValue = newValue.copy(ownerId = currentUserId())
-        collection.document(todoID).set(todoToMap(newValue)).await()
-    }
-
-    override suspend fun deleteTodo(todoID: String) {
-        val doc = collection.document(todoID).get().await()
-        val existing =
-            snapshotToToDo(doc) ?: throw NoSuchElementException("Todo with id=$todoID not found")
-
-        if (existing.ownerId != currentUserId()) {
-            throw SecurityException("Todo does not belong to signed in user")
-        }
-
-        collection.document(todoID).delete().await()
-    }
-
+    /**
+     * Converts a Firestore [DocumentSnapshot] into a [ToDo] object.
+     *
+     * @param doc The Firestore document representing a [ToDo].
+     * @return The constructed [ToDo], or `null` if required fields are missing.
+     */
     private fun snapshotToToDo(doc: DocumentSnapshot): ToDo? {
-        val uid = doc.getString("uid") ?: return null
-        val name = doc.getString("name") ?: return null
-        val description = doc.getString("description") ?: return null
-        val assigneeName = doc.getString("assigneeName") ?: return null
-        val dueDate = doc.getTimestamp("dueDate") ?: return null
-        val ownerId = doc.getString("ownerId") ?: return null
-        val statusStr = doc.getString("status") ?: ToDoStatus.CREATED.name
-        val status = ToDoStatus.valueOf(statusStr)
+    val uid = doc.getString("uid") ?: return null
+    val name = doc.getString("name") ?: return null
+    val description = doc.getString("description") ?: return null
+    val assigneeName = doc.getString("assigneeName") ?: return null
+    val dueDate = doc.getTimestamp("dueDate") ?: return null
+    val ownerId = doc.getString("ownerId") ?: return null
+    val statusStr = doc.getString("status") ?: ToDoStatus.ONGOING.name
+    val status = ToDoStatus.valueOf(statusStr)
 
-        return ToDo(uid, name, description, assigneeName, dueDate, status, ownerId)
-    }
+    return ToDo(uid, name, description, assigneeName, dueDate, status, ownerId)
+  }
 
-    private fun todoToMap(todo: ToDo): Map<String, Any?> {
-        return mapOf(
-            "uid" to todo.uid,
-            "name" to todo.name,
-            "description" to todo.description,
-            "assigneeName" to todo.assigneeName,
-            "dueDate" to todo.dueDate,
-            "status" to todo.status.name,
-            "ownerId" to todo.ownerId)
-    }
+    /**
+     * Converts a [ToDo] into a Firestore-compatible map.
+     *
+     * Used by [addTodo] and [editTodo] when writing data to Firestore.
+     *
+     * @param todo The [ToDo] to serialize.
+     * @return A map of field names to values compatible with Firestore.
+     */
+  private fun todoToMap(todo: ToDo): Map<String, Any?> {
+    return mapOf(
+        "uid" to todo.uid,
+        "name" to todo.name,
+        "description" to todo.description,
+        "assigneeName" to todo.assigneeName,
+        "dueDate" to todo.dueDate,
+        "status" to todo.status.name,
+        "ownerId" to todo.ownerId)
+  }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,14 @@
+{
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  }
+}


### PR DESCRIPTION
Complete implementation of the ToDo class and ToDos firestore repository, along with its corresponding tests and supporting Firebase Emulator utilities. 
The goal was to migrate from the bootcamp Firestore layout (a single shared todos collection) to per-users collections.
Added dueTime field to ToDo object.
The test class "ToDosRepositoryFirestoreTest" must be run with the firebase emulators running.