### PR TITLE
chore: add events repo and vm skeleton

### DIFF
--- a/app/src/main/java/com/android/gatherly/model/events/EventsRepository.kt
+++ b/app/src/main/java/com/android/gatherly/model/events/EventsRepository.kt
@@ -1,0 +1,5 @@
+package com.android.gatherly.model.events
+
+interface EventsRepository {
+  /* PLACEHOLDER */
+}

--- a/app/src/main/java/com/android/gatherly/ui/events/EventsViewModel.kt
+++ b/app/src/main/java/com/android/gatherly/ui/events/EventsViewModel.kt
@@ -1,0 +1,8 @@
+package com.android.gatherly.ui.events
+
+import androidx.lifecycle.ViewModel
+import com.android.gatherly.model.events.EventsRepository
+
+class EventsViewModel(private val eventsRepository: EventsRepository) : ViewModel() {
+  /* PLACEHOLDER */
+}


### PR DESCRIPTION
## What?
Added skeleton implementations of `EventsRepository` interface and `EventsViewModel` class to establish the architecture structure for the Events feature.

## Why?
As part of our team coordination strategy, we agreed to publish interface and ViewModel skeletons early to prevent integration conflicts. This allows team members working on different parts of the Events feature (UI, repository implementation, testing) to reference these structures and develop against consistent contracts, even while the full implementations are still in progress.

## How?
**EventsRepository Interface:**
- Created empty interface defining the contract for event data operations
- Serves as the abstraction layer between data sources and ViewModels
- Will be implemented with actual Firestore operations in subsequent PRs

**EventsViewModel:**
- Created basic ViewModel class structure
- Will be populated with state, business logic, and repository interactions in follow-up work

## Testing?
- Verified both files compile successfully
- Confirmed no breaking changes to existing code
- Structure is ready for team members to begin parallel development

## Anything Else?
This is an intentionally minimal PR focused on establishing contracts rather than implementation. The actual business logic, data operations, and state management will be added incrementally in subsequent PRs as the feature develops.

Note that CI is still not functional, even if the quality gate passed.