### PR TITLE
feat(model): add events repo interface

### DIFF
--- a/app/src/main/java/com/android/gatherly/model/event/EventsRepository.kt
+++ b/app/src/main/java/com/android/gatherly/model/event/EventsRepository.kt
@@ -1,0 +1,67 @@
+package com.android.gatherly.model.event
+
+// This file was inspired from the CS-311 bootcamp, and was adapted by an LLM (GitHub Copilot).
+
+/**
+ * Repository interface that defines all operations for managing [Event] items.
+ *
+ * This abstraction allows different data sources (e.g., Firestore, local DB, or fake data)
+ */
+interface EventsRepository {
+
+  /** Generates and returns a new unique identifier for an [Event]. */
+  fun getNewId(): String
+
+  /**
+   * Retrieves all [Event]s from the repository.
+   *
+   * @return A list of all [Event]s.
+   */
+  suspend fun getAllEvents(): List<Event>
+
+  /**
+   * Retrieves a specific [Event] by its unique identifier.
+   *
+   * @param eventId The unique identifier of the [Event] to retrieve.
+   * @return The [Event] with the specified identifier.
+   */
+  suspend fun getEvent(eventId: String): Event
+
+  /**
+   * Adds a new [Event] to the repository.
+   *
+   * @param event The [Event] to add.
+   */
+  suspend fun addEvent(event: Event)
+
+  /**
+   * Edits an existing [Event] in the repository.
+   *
+   * @param eventId The unique identifier of the [Event] to edit.
+   * @param newValue The new value for the [Event].
+   */
+  suspend fun editEvent(eventId: String, newValue: Event)
+
+  /**
+   * Deletes an [Event] from the repository.
+   *
+   * @param eventId The unique identifier of the [Event] to delete.
+   */
+  suspend fun deleteEvent(eventId: String)
+
+  /**
+   * Adds a participant to an [Event].
+   *
+   * @param eventId The identifier of the [Event].
+   * @param userId The identifier of the user to add.
+   */
+  suspend fun addParticipant(eventId: String, userId: String)
+
+  /**
+   * Removes a participant from an [Event].
+   *
+   * @param eventId The identifier of the [Event].
+   * @param userId The identifier of the user to remove.
+   */
+  suspend fun removeParticipant(eventId: String, userId: String)
+}

--- a/app/src/main/java/com/android/gatherly/model/events/EventsRepository.kt
+++ b/app/src/main/java/com/android/gatherly/model/events/EventsRepository.kt
@@ -1,5 +1,0 @@
-package com.android.gatherly.model.events
-
-interface EventsRepository {
-  /* PLACEHOLDER */
-}

--- a/app/src/main/java/com/android/gatherly/ui/events/EventsViewModel.kt
+++ b/app/src/main/java/com/android/gatherly/ui/events/EventsViewModel.kt
@@ -1,7 +1,7 @@
 package com.android.gatherly.ui.events
 
 import androidx.lifecycle.ViewModel
-import com.android.gatherly.model.events.EventsRepository
+import com.android.gatherly.model.event.EventsRepository
 
 class EventsViewModel(private val eventsRepository: EventsRepository) : ViewModel() {
   /* PLACEHOLDER */


### PR DESCRIPTION
## What?
Implemented the `EventsRepository` interface with full CRUD operations and participant management methods. Additionally, refactored the package structure by moving EventsRepository from `model.events` to `model.event` to align with the `Event` data class location.

## Why?
The empty skeleton interface (from PR #83) needed to be populated with actual method signatures to define the contract for event data operations. The package rename improves code organization by keeping all Event-related classes (`Event`, `EventsRepository`) in the same `model.event` package, following consistent naming conventions throughout the codebase.

## How?
**EventsRepository Interface Implementation:**
- `getNewId()` - Generates unique identifiers for new events
- `getAllEvents()` - Retrieves all events from the data source
- `getEvent(eventId)` - Fetches a specific event by ID
- `addEvent(event)` - Creates a new event
- `editEvent(eventId, newValue)` - Updates an existing event
- `deleteEvent(eventId)` - Removes an event
- `addParticipant(eventId, userId)` - Adds a user to an event's participant list
- `removeParticipant(eventId, userId)` - Removes a user from an event's participant list

**Package Refactoring:**
- Moved `EventsRepository.kt` from `com.android.gatherly.model.events` to `com.android.gatherly.model.event`
- Updated import statement in `EventsViewModel.kt` to reflect the new package location
- Ensures consistency with where `Event.kt` and `EventStatus` are located

## Testing?
- Verified interface compiles successfully with all method signatures
- Confirmed EventsViewModel correctly imports from the new package location
- No breaking changes - interface can now be implemented by concrete repository classes (Firestore, local, fake)

## Anything Else?
This interface is inspired by and adapted from the CS-311 Bootcamp TodosRepository pattern. The participant management methods (`addParticipant`, `removeParticipant`) are Event-specific additions that don't exist in the Todo model, reflecting the social/collaborative nature of events. Concrete implementations (e.g., `EventsRepositoryFirestore`) will be added in subsequent PRs.