### PR TITLE
chore(profile): put search by uid placeholder in profile repo

### DIFF
--- a/app/src/main/java/com/android/gatherly/model/profile/ProfileRepository.kt
+++ b/app/src/main/java/com/android/gatherly/model/profile/ProfileRepository.kt
@@ -10,4 +10,6 @@ interface ProfileRepository {
   suspend fun deleteProfile(uid: String)
 
   suspend fun isUidRegistered(uid: String): Boolean
+
+  suspend fun findProfilesByUidSubstring(uidSubstring: String): List<Profile>
 }

--- a/app/src/main/java/com/android/gatherly/model/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/gatherly/model/profile/ProfileRepositoryFirestore.kt
@@ -21,4 +21,8 @@ class ProfileRepositoryFirestore : ProfileRepository {
   override suspend fun isUidRegistered(uid: String): Boolean {
     TODO("Not yet implemented")
   }
+
+  override suspend fun findProfilesByUidSubstring(uidSubstring: String): List<Profile> {
+    TODO("Not yet implemented")
+  }
 }


### PR DESCRIPTION
Add new method to ProfileRepository interface which takes a uid substring and return a list of Profiles.
Add placeholder method for this function to ProfileRepositoryFirestore.
No implementation yet this pr is to unblock teammates!