### PR TITLE
feat(model): add focus session dataclass

### DIFF
--- a/app/src/main/java/com/android/gatherly/model/focusSession/FocusSession.kt
+++ b/app/src/main/java/com/android/gatherly/model/focusSession/FocusSession.kt
@@ -15,6 +15,6 @@ data class FocusSession(
     val duration: Duration = Duration.ZERO,
     /** Timestamp indicating when the focus session started */
     val startedAt: Timestamp? = null,
-    /** Timestamp indicating when the focus session started */
+    /** Timestamp indicating when the focus session ended */
     val endedAt: Timestamp? = null
 )


### PR DESCRIPTION
## What?
Added the `FocusSession` data class to represent focus sessions within the app. This includes fields for focus session identification (`focusSessionId`), creator identification (`creatorId`), Todo linked with the focus session (`linkedTodoId`), duration of the focus session (`duration`), start and end time of the focus session (`startedAt`, `endedAt`). Closes #130.

## Why?
This establishes the foundational data structure needed for the focus sessions feature, which allows users to get an overview or all of their focus sessions started from the Timer Screen.

## How?
Implemented as a straightforward Kotlin data class with six fields:
- `focusSessionId`: Unique identifier for the focus session
- `creatorId`: Tracks who created the focus session
- `linkedTodoId`: ID of the ToDo this focus session was linked to
- `duration`: duration of the session in seconds
- `startedAt`: Timestamp indicating when the focus session started
- `endedAt`: Timestamp indicating when the focus session ended

## Testing?
No tests included - this is a pure data class with no business logic. Testing will be covered when the repository layer is implemented in a follow-up PR.

## Anything Else?
The focus sessions repository implementation will follow in a separate branch/PR once this baseline data structure is merged.