### PR TITLE
feat(model): add focus sessions repo interface

### DIFF
--- a/app/src/main/java/com/android/gatherly/model/focusSession/FocusSessionsRepository.kt
+++ b/app/src/main/java/com/android/gatherly/model/focusSession/FocusSessionsRepository.kt
@@ -30,7 +30,7 @@ interface FocusSessionsRepository {
   /**
    * Returns the [FocusSession] with the given ID.
    *
-   * @param focusSessionId The unique identifier of the group.
+   * @param focusSessionId The unique identifier of the Focus Session.
    * @return The focus session with the specified ID.
    * @throws NoSuchElementException if no focus session with the given ID exists.
    */


### PR DESCRIPTION
## What?
Added the `FocusSessionsRepository` interface defining the contract for focus sessions management operations. Closes #172.

## Why?
This interface establishes the repository pattern for focus sessions, providing a clean abstraction layer between the data source and the rest of the app. It defines all necessary operations for the focus sessions feature while keeping implementation details (like Firestore specifics) separate and testable.

## How?
Created a comprehensive interface with 11 methods covering:
- **CRUD operations**: `addFocusSession()`, `editFocusSession()`, `deleteFocusSession()`, `getFocusSession()`, `getAllFocusSessions()`, `getUserFocusSessions()`
- **ID generation**: `getNewId()`

Key design decisions:
- Used suspend functions for async operations (Firestore compatibility)
- Built-in security constraints documented in KDoc
- Separation of concerns: `getAllFocusSessions()` vs `getUserFocusSessions()` for different use cases

## Testing?
No tests included yet - this is an interface definition. Tests will be added with the Firestore implementation in the follow-up PR.

## Anything Else?
This is just a contractual PR with no implementations. The Firestore implementation (`FocusSessionsRepositoryFirestore`) will follow in a separate PR, along with comprehensive unit tests using mocked Firebase dependencies.
