### PR TITLE
Fix/200 make SettingsScreen scrollable 

### DIFF
--- a/app/src/androidTest/java/com/android/gatherly/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/gatherly/ui/settings/SettingsScreenTest.kt
@@ -274,4 +274,16 @@ class SettingsScreenTest : FirestoreGatherlyTest() {
 
     composeRule.onNodeWithText("Username is valid").assertDoesNotExist() // optional
   }
+
+  @Test
+  fun settingsScreen_isScrollable_andSaveButtonReachable() {
+    /**
+     * Scrolls to the last editable field (School Year) to verify that it can be reached even if
+     * it’s not initially visible on smaller screens.
+     */
+    composeRule
+        .onNodeWithTag(SettingsScreenTestTags.SCHOOL_YEAR_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/com/android/gatherly/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/gatherly/ui/settings/SettingsScreen.kt
@@ -20,14 +20,11 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.credentials.CredentialManager
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.gatherly.R
-import com.android.gatherly.model.profile.ProfileLocalRepository
 import com.android.gatherly.ui.navigation.*
-import com.android.gatherly.ui.theme.GatherlyTheme
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 
@@ -278,11 +275,4 @@ fun SettingsField(
                   .testTag("${testTag}_error"))
     }
   }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun SettingsScreenPreview() {
-  val fakeViewModel = SettingsViewModel(ProfileLocalRepository())
-  GatherlyTheme(darkTheme = true) { SettingsScreen(fakeViewModel) }
 }


### PR DESCRIPTION
# Description
This PR makes the Settings screen scrollable  while keeping the Save button fixed at the bottom for better user experience.  
It closes #200.

## Changes
- Added vertical scrolling to the main content area of the Settings screen.  
- Kept the Save button always visible.

## Files

#### Modified
- `SettingsScreen.kt` Added scrollable column and fixed Save button layout.  

## Testing
- Confirmed that the Save button remains visible and functional at all times by launching the app
- Confirmed the settings screen tests still pass and added a test to ensure screen is scrollable
- Line Coverage 100 %

## Screenshots
[Screen_recording_20251104_141534.webm](https://github.com/user-attachments/assets/3ca66a76-12a3-4e74-98cd-8788ecc3c1d2)