### PR TITLE
Fix/242 make app locked in portrait mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/title_activity_main"
-            android:theme="@style/Theme.SampleApp">
+            android:theme="@style/Theme.SampleApp"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
# Description
This small PR locks the MainActivity of the Gatherly app to portrait orientation to prevent UI issues when the device is rotated. It closes #242. This is a temporary fix until landscape is fully supported by the ui.

## Changes
- Added `android:screenOrientation="portrait"` to the MainActivity tag in AndroidManifest.xml.

## Files 

#### Added
- None

#### Modified
- `AndroidManifest.xml` added `screenOrientation` attribute to MainActivity

## Testing
- Verified that the app remains in portrait mode on Android phone emulators.

