### PR TITLE
Feat/292 notification repo interface

### DIFF
--- a/app/src/main/java/com/android/gatherly/model/notification/NotificationsRepository.kt
+++ b/app/src/main/java/com/android/gatherly/model/notification/NotificationsRepository.kt
@@ -6,7 +6,10 @@ interface NotificationsRepository {
   /** Returns a new unique ID for a notification. */
   fun getNewId(): String
 
-  /** Returns a list of all notifications for the specified user, ordered by emission time. */
+  /**
+   * Returns a list of all notifications for the specified user, ordered by emission time
+   * (decreasing).
+   */
   suspend fun getUserNotifications(userId: String): List<Notification>
 
   /** Returns the notification with the given ID, or throws NoSuchElementException if not found. */


### PR DESCRIPTION
## What?
Implements the NotificationsRepository interface defining the contract for notification operations. Provides methods for creating, retrieving, updating, and deleting notifications. Closes #292.

## Why?
Establishes a clear interface contract for notification management that:
- Enables development of Firestore and Local repository implementations
- Ensures consistent behavior across different storage backends
- Follows existing repository patterns (ToDos, Events, Groups)

## How?
**Repository Interface (`NotificationsRepository.kt`):**

Six core methods:
- `getNewId()` - Generate unique notification IDs
- `getUserNotifications(userId)` - Fetch user's notifications ordered by emission time (in decreasing order, to get the most recent notifications first)
- `getNotification(notificationId)` - Fetch specific notification
- `addNotification(notification)` - Create new notification
- `markAsRead(notificationId)` - Mark notification as read
- `deleteNotification(notificationId)` - Remove notification

**Design Notes:**
- Explicit `userId` parameter for flexibility at call site
- Filtering to be handled in ViewModels (consistent with other VMs)

## Testing?
No testing, since this is contractual code.
Tests will be added in implementation PRs (`NotificationsLocalRepository` and `NotificationsRepositoryFirestore`).

## Anything Else?
**Dependencies:** Requires PR #290.

**Enables:** Local and Firestore implementations, ViewModel development, UI integration