### PR TITLE
fix: missing repository in test

### DIFF
--- a/app/src/androidTest/java/com/android/gatherly/ui/events/EventsOverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/gatherly/ui/events/EventsOverviewScreenTest.kt
@@ -500,7 +500,10 @@ class EventsOverviewScreenTest {
     mockitoUtils.chooseCurrentUser("anon", true)
 
     eventsViewModel =
-        EventsViewModel(eventsRepository = eventsRepository, profileRepository = profileRepository, authProvider = { mockitoUtils.mockAuth })
+        EventsViewModel(
+            eventsRepository = eventsRepository,
+            profileRepository = profileRepository,
+            authProvider = { mockitoUtils.mockAuth })
     composeTestRule.setContent { EventsScreen(eventsViewModel = eventsViewModel) }
 
     composeTestRule.onNodeWithTag(EventsScreenTestTags.BROWSE_TITLE).assertIsDisplayed()


### PR DESCRIPTION
# Description
Fixed a line that was missing profile repository in the EventsOverviewScreenTest.kt file.

## Changes
This was most likely caused by a merging that wasn't well done and caused the CI in the main to fail.

## Files 
#### Modified
- `EventsOverviewScreenTest.kt`