### PR TITLE
feat: add loading messages to events & todos overview screens

### DIFF
--- a/app/src/main/java/com/android/gatherly/ui/events/EventsScreen.kt
+++ b/app/src/main/java/com/android/gatherly/ui/events/EventsScreen.kt
@@ -265,7 +265,18 @@ fun EventsScreen(
                     color = MaterialTheme.colorScheme.onBackground)
               }
 
-              if (browserEvents.isNotEmpty()) {
+              if (uiState.isLoading) {
+                // Events are loading so display that text
+                item {
+                  Text(
+                      stringResource(R.string.events_loading),
+                      modifier = Modifier.fillMaxWidth().padding(8.dp),
+                      textAlign = TextAlign.Center,
+                      style = MaterialTheme.typography.titleMedium,
+                      fontWeight = FontWeight.Bold,
+                      color = MaterialTheme.colorScheme.onBackground)
+                }
+              } else if (browserEvents.isNotEmpty()) {
                 items(browserEvents.size) { index ->
                   BrowserEventsItem(
                       event = browserEvents[index],

--- a/app/src/main/java/com/android/gatherly/ui/events/EventsViewModel.kt
+++ b/app/src/main/java/com/android/gatherly/ui/events/EventsViewModel.kt
@@ -43,7 +43,8 @@ data class UIState(
     val signedOut: Boolean = false,
     val errorMsg: String? = null,
     val currentUserId: String = "",
-    val isAnon: Boolean = true
+    val isAnon: Boolean = true,
+    val isLoading: Boolean = false
 )
 /**
  * Function that retrieves "drawable" events, i.e. those which are not past, and have a valid
@@ -93,6 +94,7 @@ class EventsViewModel(
    * @param currentUserId the ID of the current user
    */
   suspend fun refreshEvents(currentUserId: String) {
+    _uiState.value = _uiState.value.copy(isLoading = true)
     val events = eventsRepository.getAllEvents()
     _uiState.value =
         _uiState.value.copy(
@@ -108,6 +110,7 @@ class EventsViewModel(
                 },
             currentUserId = currentUserId,
             isAnon = authProvider().currentUser?.isAnonymous ?: true)
+    _uiState.value = _uiState.value.copy(isLoading = false)
   }
 
   /**

--- a/app/src/main/java/com/android/gatherly/ui/todo/OverviewScreen.kt
+++ b/app/src/main/java/com/android/gatherly/ui/todo/OverviewScreen.kt
@@ -160,131 +160,139 @@ fun OverviewScreen(
             }
       },
       content = { pd ->
-        Box(
-            modifier =
-                Modifier.fillMaxSize().clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null) {
-                      focusManager.clearFocus()
-                    }) {
-              var searchQuery by remember { mutableStateOf("") }
+        if (uiState.isLoading) {
+          Box(contentAlignment = Alignment.Center) {
+            Text(modifier = Modifier.padding(pd), text = stringResource(R.string.todos_loading))
+          }
+        } else {
+          Box(
+              modifier =
+                  Modifier.fillMaxSize().clickable(
+                      interactionSource = remember { MutableInteractionSource() },
+                      indication = null) {
+                        focusManager.clearFocus()
+                      }) {
+                var searchQuery by remember { mutableStateOf("") }
 
-              Column(modifier = Modifier.padding(pd)) {
-                Row(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .height(dimensionResource(R.dimen.todo_overview_top_row_height))
-                            .padding(
-                                bottom =
-                                    dimensionResource(R.dimen.todos_overview_vertical_padding))) {
-                      OutlinedTextField(
-                          value = searchQuery,
-                          onValueChange = { newText ->
-                            searchQuery = newText
-                            overviewViewModel.searchTodos(newText)
-                          },
-                          modifier =
-                              Modifier.weight(1f)
-                                  .padding(
-                                      horizontal =
-                                          dimensionResource(
-                                              R.dimen.todos_overview_horizontal_padding))
-                                  .testTag(OverviewScreenTestTags.SEARCH_BAR),
-                          label = { Text(stringResource(R.string.todos_search_bar_label)) },
-                          singleLine = true,
-                          colors =
-                              OutlinedTextFieldDefaults.colors(
-                                  focusedContainerColor = MaterialTheme.colorScheme.background,
-                                  unfocusedContainerColor = MaterialTheme.colorScheme.background,
-                                  unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
-                                  focusedTextColor = MaterialTheme.colorScheme.onBackground,
-                              ))
-                      SortMenu(
-                          currentOrder = uiState.sortOrder,
-                          onSortSelected = { overviewViewModel.setSortOrder(it) })
-                    }
-
-                if (todos.isNotEmpty()) {
-                  LazyColumn(
-                      contentPadding =
-                          PaddingValues(
-                              vertical =
-                                  dimensionResource(id = R.dimen.todos_overview_vertical_padding)),
+                Column(modifier = Modifier.padding(pd)) {
+                  Row(
                       modifier =
                           Modifier.fillMaxWidth()
+                              .height(dimensionResource(R.dimen.todo_overview_top_row_height))
                               .padding(
-                                  horizontal =
-                                      dimensionResource(
-                                          id = R.dimen.todos_overview_horizontal_padding))
-                              .padding(pd)
-                              .testTag(OverviewScreenTestTags.TODO_LIST)) {
-
-                        // ONGOING SECTION
-                        if (ongoingTodos.isNotEmpty()) {
-                          item {
-                            Text(
-                                text = stringResource(R.string.todos_ongoing_section_label),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                modifier =
-                                    Modifier.padding(
-                                        vertical =
+                                  bottom =
+                                      dimensionResource(R.dimen.todos_overview_vertical_padding))) {
+                        OutlinedTextField(
+                            value = searchQuery,
+                            onValueChange = { newText ->
+                              searchQuery = newText
+                              overviewViewModel.searchTodos(newText)
+                            },
+                            modifier =
+                                Modifier.weight(1f)
+                                    .padding(
+                                        horizontal =
                                             dimensionResource(
-                                                id =
-                                                    R.dimen
-                                                        .todos_overview_section_text_vertical_padding)))
-                          }
-                          items(ongoingTodos.size) { index ->
-                            ToDoItem(
-                                todo = ongoingTodos[index],
-                                onClick = { onSelectTodo(ongoingTodos[index]) },
-                                isChecked = false,
-                                onCheckedChange = { checked ->
-                                  val newStatus =
-                                      if (checked) ToDoStatus.ENDED else ToDoStatus.ONGOING
-                                  overviewViewModel.onCheckboxChanged(
-                                      ongoingTodos[index].uid, newStatus)
-                                })
-                          }
-                        }
-
-                        // COMPLETED SECTION
-                        if (completedTodos.isNotEmpty()) {
-                          item {
-                            Text(
-                                text = stringResource(R.string.todos_completed_section_label),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold,
-                                modifier =
-                                    Modifier.padding(
-                                        vertical =
-                                            dimensionResource(
-                                                id =
-                                                    R.dimen
-                                                        .todos_overview_section_text_vertical_padding)))
-                          }
-                          items(completedTodos.size) { index ->
-                            ToDoItem(
-                                todo = completedTodos[index],
-                                onClick = { onSelectTodo(completedTodos[index]) },
-                                isChecked = true,
-                                onCheckedChange = { checked ->
-                                  val newStatus =
-                                      if (checked) ToDoStatus.ENDED else ToDoStatus.ONGOING
-                                  overviewViewModel.onCheckboxChanged(
-                                      completedTodos[index].uid, newStatus)
-                                })
-                          }
-                        }
+                                                R.dimen.todos_overview_horizontal_padding))
+                                    .testTag(OverviewScreenTestTags.SEARCH_BAR),
+                            label = { Text(stringResource(R.string.todos_search_bar_label)) },
+                            singleLine = true,
+                            colors =
+                                OutlinedTextFieldDefaults.colors(
+                                    focusedContainerColor = MaterialTheme.colorScheme.background,
+                                    unfocusedContainerColor = MaterialTheme.colorScheme.background,
+                                    unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+                                    focusedTextColor = MaterialTheme.colorScheme.onBackground,
+                                ))
+                        SortMenu(
+                            currentOrder = uiState.sortOrder,
+                            onSortSelected = { overviewViewModel.setSortOrder(it) })
                       }
-                } else {
-                  Text(
-                      modifier =
-                          Modifier.padding(pd).testTag(OverviewScreenTestTags.EMPTY_TODO_LIST_MSG),
-                      text = stringResource(R.string.no_todos_text))
+
+                  if (todos.isNotEmpty()) {
+                    LazyColumn(
+                        contentPadding =
+                            PaddingValues(
+                                vertical =
+                                    dimensionResource(
+                                        id = R.dimen.todos_overview_vertical_padding)),
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .padding(
+                                    horizontal =
+                                        dimensionResource(
+                                            id = R.dimen.todos_overview_horizontal_padding))
+                                .padding(pd)
+                                .testTag(OverviewScreenTestTags.TODO_LIST)) {
+
+                          // ONGOING SECTION
+                          if (ongoingTodos.isNotEmpty()) {
+                            item {
+                              Text(
+                                  text = stringResource(R.string.todos_ongoing_section_label),
+                                  style = MaterialTheme.typography.titleMedium,
+                                  fontWeight = FontWeight.Bold,
+                                  modifier =
+                                      Modifier.padding(
+                                          vertical =
+                                              dimensionResource(
+                                                  id =
+                                                      R.dimen
+                                                          .todos_overview_section_text_vertical_padding)))
+                            }
+                            items(ongoingTodos.size) { index ->
+                              ToDoItem(
+                                  todo = ongoingTodos[index],
+                                  onClick = { onSelectTodo(ongoingTodos[index]) },
+                                  isChecked = false,
+                                  onCheckedChange = { checked ->
+                                    val newStatus =
+                                        if (checked) ToDoStatus.ENDED else ToDoStatus.ONGOING
+                                    overviewViewModel.onCheckboxChanged(
+                                        ongoingTodos[index].uid, newStatus)
+                                  })
+                            }
+                          }
+
+                          // COMPLETED SECTION
+                          if (completedTodos.isNotEmpty()) {
+                            item {
+                              Text(
+                                  text = stringResource(R.string.todos_completed_section_label),
+                                  style = MaterialTheme.typography.titleMedium,
+                                  fontWeight = FontWeight.Bold,
+                                  modifier =
+                                      Modifier.padding(
+                                          vertical =
+                                              dimensionResource(
+                                                  id =
+                                                      R.dimen
+                                                          .todos_overview_section_text_vertical_padding)))
+                            }
+                            items(completedTodos.size) { index ->
+                              ToDoItem(
+                                  todo = completedTodos[index],
+                                  onClick = { onSelectTodo(completedTodos[index]) },
+                                  isChecked = true,
+                                  onCheckedChange = { checked ->
+                                    val newStatus =
+                                        if (checked) ToDoStatus.ENDED else ToDoStatus.ONGOING
+                                    overviewViewModel.onCheckboxChanged(
+                                        completedTodos[index].uid, newStatus)
+                                  })
+                            }
+                          }
+                        }
+                  } else {
+                    Text(
+                        modifier =
+                            Modifier.padding(pd)
+                                .testTag(OverviewScreenTestTags.EMPTY_TODO_LIST_MSG),
+                        text = stringResource(R.string.no_todos_text))
+                  }
                 }
               }
-            }
+        }
       })
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="todos_date_ascending_sort_button_text">Date ascending</string>
     <string name="todos_alphabetical_sort_button_text">Alphabetical</string>
     <string name="todos_sort_menu_check_icon_label">Selected</string>
+    <string name="todos_loading">Loading your todos …</string>
 
     <!-- Sign In Page. -->
     <string name="web_client_id">854490974901-rc0seqlo7nbm1net10ujpte2ckkrsgn2.apps.googleusercontent.com</string>
@@ -102,6 +103,7 @@
     <string name="events_participant_placeholder">Add or remove a participant</string>
     <string name="events_delete_warning">Warning! You are deleting an event</string>
     <string name="events_delete_warning_text">This action cannot be reversed. Are you sure?</string>
+    <string name="events_loading">Loading events …</string>
 
     <string name="delete">Yes, Delete</string>
     <string name="cancel">No, Cancel</string>


### PR DESCRIPTION
# Description
This PR introduces loading messages to screens that can take some time getting their information from Firestore. It closes #321 

## Changes
This PR adds a loading message to the todos and events screens while waiting on the Firestore response.

## Files 
#### Modified
- EventsScreen.kt
- EventsViewModel.kt
- OverviewScreen.kt
- string.xml

## Testing
Line coverage is at 100%.

## Screenshots
<img src="https://github.com/user-attachments/assets/8f0e2998-9913-42ae-850c-14b9a5e07e66" width="300" />
<img src="https://github.com/user-attachments/assets/3bab2323-0e0d-4d51-adb9-a3965304de1a" width="300" />

