### PR TITLE
fix: redesign add groups

### DIFF
--- a/app/src/androidTest/java/com/android/gatherly/ui/groups/AddGroupScreenTest.kt
+++ b/app/src/androidTest/java/com/android/gatherly/ui/groups/AddGroupScreenTest.kt
@@ -1,5 +1,6 @@
 package com.android.gatherly.ui.groups
 
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -186,6 +187,12 @@ class AddGroupScreenTest {
     composeTestRule
         .onNodeWithTag(AddGroupScreenTestTags.GROUP_NAME_FIELD)
         .performTextInput("Chess Club")
+
+    // Type group name
+    composeTestRule
+        .onNodeWithTag(AddGroupScreenTestTags.GROUP_DESCRIPTION_FIELD)
+        .assertIsDisplayed()
+        .performTextInput("Best chess players")
 
     composeTestRule.onNodeWithTag(AddGroupScreenTestTags.BUTTON_CREATE_GROUP).performClick()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,8 +191,9 @@
 
     <!-- Groups -->
     <string name="add_group_button_label">Add New Group</string>
-    <string name="group_name_bar_label">Group Name</string>
+    <string name="group_name_bar_label">Group Name*</string>
     <string name="group_name_bar_placeholder">Name the Group</string>
+    <string name="group_description_bar_placeholder">Describe the Group</string>
     <string name="group_members_text_singular">member</string>
     <string name="group_members_text_plural">members</string>
 

--- a/app/src/test/java/com/android/gatherly/viewmodel/groups/add/AddGroupViewModelTest.kt
+++ b/app/src/test/java/com/android/gatherly/viewmodel/groups/add/AddGroupViewModelTest.kt
@@ -10,11 +10,12 @@ import com.android.gatherly.viewmodel.groups.add.AddGroupViewModelTestData.ALL_F
 import com.android.gatherly.viewmodel.groups.add.AddGroupViewModelTestData.CURRENT_USER_PROFILE
 import com.android.gatherly.viewmodel.groups.add.AddGroupViewModelTestData.FRIEND_ALICE
 import com.android.gatherly.viewmodel.groups.add.AddGroupViewModelTestData.FRIEND_BOB
+import com.android.gatherly.viewmodel.groups.add.AddGroupViewModelTestData.FRIEND_CHARLIE
 import com.android.gatherly.viewmodel.groups.add.AddGroupViewModelTestData.TEST_USER_ID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -49,7 +50,7 @@ class AddGroupViewModelTest {
   private lateinit var notificationsRepository: NotificationsRepository
   private lateinit var mockitoUtils: MockitoUtils
 
-  private val testDispatcher = StandardTestDispatcher()
+  private val testDispatcher = UnconfinedTestDispatcher()
 
   /**
    * Sets up test fixtures before each test.
@@ -108,7 +109,7 @@ class AddGroupViewModelTest {
         assertEquals("", state.description)
         assertNull(state.nameError)
         assertEquals(ALL_FRIENDS, state.friendsList)
-        assertTrue(state.selectedFriendIds.isEmpty())
+        assertTrue(state.selectedFriends.isEmpty())
         assertFalse(state.isFriendsLoading)
         assertNull(state.friendsError)
         assertFalse(state.isSaving)
@@ -257,11 +258,11 @@ class AddGroupViewModelTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        viewModel.onFriendToggled(FRIEND_ALICE.uid)
+        viewModel.onFriendToggled(FRIEND_ALICE)
 
         val state = viewModel.uiState.value
-        assertTrue(state.selectedFriendIds.contains(FRIEND_ALICE.uid))
-        assertEquals(1, state.selectedFriendIds.size)
+        assertTrue(state.selectedFriends.contains(FRIEND_ALICE))
+        assertEquals(1, state.selectedFriends.size)
       }
 
   /**
@@ -276,12 +277,12 @@ class AddGroupViewModelTest {
         advanceUntilIdle()
 
         // Select then deselect
-        viewModel.onFriendToggled(FRIEND_ALICE.uid)
-        viewModel.onFriendToggled(FRIEND_ALICE.uid)
+        viewModel.onFriendToggled(FRIEND_ALICE)
+        viewModel.onFriendToggled(FRIEND_ALICE)
 
         val state = viewModel.uiState.value
-        assertFalse(state.selectedFriendIds.contains(FRIEND_ALICE.uid))
-        assertTrue(state.selectedFriendIds.isEmpty())
+        assertFalse(state.selectedFriends.contains(FRIEND_ALICE))
+        assertTrue(state.selectedFriends.isEmpty())
       }
 
   /**
@@ -295,13 +296,13 @@ class AddGroupViewModelTest {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        viewModel.onFriendToggled(FRIEND_ALICE.uid)
-        viewModel.onFriendToggled(FRIEND_BOB.uid)
+        viewModel.onFriendToggled(FRIEND_ALICE)
+        viewModel.onFriendToggled(FRIEND_BOB)
 
         val state = viewModel.uiState.value
-        assertEquals(2, state.selectedFriendIds.size)
-        assertTrue(state.selectedFriendIds.contains(FRIEND_ALICE.uid))
-        assertTrue(state.selectedFriendIds.contains(FRIEND_BOB.uid))
+        assertEquals(2, state.selectedFriends.size)
+        assertTrue(state.selectedFriends.contains(FRIEND_ALICE))
+        assertTrue(state.selectedFriends.contains(FRIEND_BOB))
       }
 
   /**
@@ -318,8 +319,8 @@ class AddGroupViewModelTest {
 
         viewModel.onNameChanged("Study Group")
         viewModel.onDescriptionChanged("Weekly study sessions")
-        viewModel.onFriendToggled(FRIEND_ALICE.uid)
-        viewModel.onFriendToggled(FRIEND_BOB.uid)
+        viewModel.onFriendToggled(FRIEND_ALICE)
+        viewModel.onFriendToggled(FRIEND_BOB)
 
         viewModel.saveGroup()
         advanceUntilIdle()
@@ -563,5 +564,22 @@ class AddGroupViewModelTest {
         assertFalse(state.friendsList.contains(FRIEND_BOB))
         assertFalse(state.isFriendsLoading)
         assertNull(state.friendsError) // No error because the operation succeeds partially
+      }
+
+  /** Checks that searching and then clearing the search query has the intended behaviour */
+  @Test
+  fun filterFriendsCorrectlyFilters() =
+      runTest(testDispatcher) {
+        val viewModel = createViewModel()
+
+        viewModel.filterFriends("a")
+        advanceUntilIdle()
+
+        assertEquals(listOf(FRIEND_ALICE, FRIEND_CHARLIE), viewModel.uiState.value.friendsList)
+
+        viewModel.filterFriends("")
+        advanceUntilIdle()
+
+        assertEquals(ALL_FRIENDS, viewModel.uiState.value.friendsList)
       }
 }


### PR DESCRIPTION
# Description
This PR introduces a fixing up of the add groups UI. It closes #450 

## Changes
The previous add group UI didn't have the intended description field. It also had a few problems with displaying checkboxes of the people who were selected (if you searched and selected a name, other names would be selected when the search was cleared, see below). The checkbox problem was fixed by moving logic code that didn't belong in the UI to the VM, with new functions. The colors in light mode were also quite off and the fields were made to be without outline.

## Files 

#### Modified
- AddGroupScreenTest.kt
- AddGroupScreen.kt
- AddGroupViewModel.kt
- strings.xml
- AddGroupViewModelTest.kt

## Testing
Line coverage is at 100%.

## Screenshots

### Before

https://github.com/user-attachments/assets/f2b0d5cf-026b-452d-b2f7-b14fb270a75f

### After

<img src="https://github.com/user-attachments/assets/f34f7f76-e647-4faf-938c-b769eb0ea552" width="300"/>
<img src="https://github.com/user-attachments/assets/c57404b9-6c3c-4e7d-8c0f-5855c2a887f2" width="300"/>
